### PR TITLE
added support for ConvRaw with boolean

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -110,6 +110,8 @@ The crate provides other supporting derive macros associated with bitfield funct
 
 It will implement `TryFrom<T> for Enum` for all builtin integer types `T`, and `From<Enum> for T` for all types that can fit all the enum discriminants.
 
+If the enum only contains two variants with discriminants 0 and 1 (in any order), it will also implement `From<bool> for Enum` and `From<Enum> for bool`.
+
 ## `UnwrapBits`
 
 `UnwrapBits` is a derive macro to implement `Bits<T> for U`, `WithBits<T> for U` and `SetBits<T> for U` for a type `T` and all builtin integer types `U` used as bitfield storage types.

--- a/src/example.rs
+++ b/src/example.rs
@@ -181,9 +181,9 @@ bitfield! {
     }
 }
 
-/// An enum showcasing the `ConvRaw` derive.
+/// An enum showcasing the `ConvRaw` derive for converting from/into integers.
 #[derive(ConvRaw)]
-pub enum ConvRawExample {
+pub enum ConvRawIntExample {
     A,
     B = 2,
     C,
@@ -191,6 +191,13 @@ pub enum ConvRawExample {
     E = 1,
     F = -128,
     G = 128,
+}
+
+/// An enum showcasing the `ConvRaw` derive for converting from/into booleans.
+#[derive(ConvRaw)]
+pub enum ConvRawBoolExample {
+    False, // Implicitly, this value is treated as 0 (false).
+    True,
 }
 
 #[cfg(feature = "nightly")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use macros::with_bits;
 pub use macros::set_bits;
 
 /// A derive macro to implement any applicable conversion traits between an enum and the builtin
-/// integer types corresponding to variant discriminants.
+/// integer and boolean types corresponding to variant discriminants.
 #[doc = include_str!("../usage_examples/conv_raw.md")]
 pub use macros::ConvRaw;
 

--- a/usage_examples/conv_raw.md
+++ b/usage_examples/conv_raw.md
@@ -24,8 +24,8 @@ pub enum ConvRawBoolExample {
 ```
 
 This will implement:
-- `TryFrom<T> for ConvRawIntExample` for all integer types `T`
-- `UnsafeFrom<T> for ConvRawIntExample` for all integer types `T`
-- `From<ConvRawIntExample> for T` for all integer types `T` that contain all discriminants; in this case, all signed integer types with `>= 16` bits (`i16`, `i32`, `i64`, `i128`)
+- `TryFrom<T> for ConvRawIntExample`, `TryFrom<T> for ConvRawBoolExample` for all integer types `T`
+- `UnsafeFrom<T> for ConvRawIntExample`, `UnsafeFrom<T> for ConvRawBoolExample` for all integer types `T`
+- `From<ConvRawIntExample> for T`, `From<ConvRawBoolExample> for T` for all integer types `T` that contain all discriminants; in this case, all signed integer types with `>= 16` bits (`i16`, `i32`, `i64`, `i128`)
 - `From<bool> for ConvRawBoolExample`
 - `From<ConvRawBoolExample> for bool`

--- a/usage_examples/conv_raw.md
+++ b/usage_examples/conv_raw.md
@@ -5,7 +5,7 @@
 # use proc_bitfield::ConvRaw;
 /// An enum showcasing the `ConvRaw` derive.
 #[derive(ConvRaw)]
-pub enum ConvRawExample {
+pub enum ConvRawIntExample {
     A,
     B = 2,
     C,
@@ -14,9 +14,18 @@ pub enum ConvRawExample {
     F = -128,
     G = 128,
 }
+
+/// An enum showcasing the `ConvRaw` derive when allowing for boolean values.
+#[derive(ConvRaw)]
+pub enum ConvRawBoolExample {
+    False, // Implicitly, this value is treated as 0 (false).
+    True,
+}
 ```
 
 This will implement:
-- `TryFrom<T> for ConvRawExample` for all integer types `T`
-- `UnsafeFrom<T> for ConvRawExample` for all integer types `T`
-- `From<ConvRawExample> for T` for all integer types `T` that contain all discriminants; in this case, all signed integer types with `>= 16` bits (`i16`, `i32`, `i64`, `i128`)
+- `TryFrom<T> for ConvRawIntExample` for all integer types `T`
+- `UnsafeFrom<T> for ConvRawIntExample` for all integer types `T`
+- `From<ConvRawIntExample> for T` for all integer types `T` that contain all discriminants; in this case, all signed integer types with `>= 16` bits (`i16`, `i32`, `i64`, `i128`)
+- `From<bool> for ConvRawBoolExample`
+- `From<ConvRawBoolExample> for bool`

--- a/usage_examples/conv_raw.md
+++ b/usage_examples/conv_raw.md
@@ -3,7 +3,7 @@
 
 ```rust
 # use proc_bitfield::ConvRaw;
-/// An enum showcasing the `ConvRaw` derive.
+/// An enum showcasing the `ConvRaw` derive for integers.
 #[derive(ConvRaw)]
 pub enum ConvRawIntExample {
     A,
@@ -14,6 +14,14 @@ pub enum ConvRawIntExample {
     F = -128,
     G = 128,
 }
+```
+
+This will implement:
+- `TryFrom<T> for ConvRawIntExample` for all integer types `T`
+- `UnsafeFrom<T> for ConvRawIntExample` for all integer types `T`
+- `From<ConvRawIntExample> for T` for all integer types `T` that contain all discriminants; in this case, all signed integer types with `>= 16` bits (`i16`, `i32`, `i64`, `i128`)
+- `From<bool> for ConvRawBoolExample`
+- `From<ConvRawBoolExample> for bool`
 
 /// An enum showcasing the `ConvRaw` derive when allowing for boolean values.
 #[derive(ConvRaw)]
@@ -24,8 +32,8 @@ pub enum ConvRawBoolExample {
 ```
 
 This will implement:
-- `TryFrom<T> for ConvRawIntExample`, `TryFrom<T> for ConvRawBoolExample` for all integer types `T`
-- `UnsafeFrom<T> for ConvRawIntExample`, `UnsafeFrom<T> for ConvRawBoolExample` for all integer types `T`
-- `From<ConvRawIntExample> for T`, `From<ConvRawBoolExample> for T` for all integer types `T` that contain all discriminants; in this case, all signed integer types with `>= 16` bits (`i16`, `i32`, `i64`, `i128`)
+- `TryFrom<T> for ConvRawBool` for all integer types `T`
+- `UnsafeFrom<T> for ConvRawBool` for all integer types `T`
+- `From<ConvRawBool> for T` for all integer types `T` that contain all discriminants; in this case, all integer types
 - `From<bool> for ConvRawBoolExample`
 - `From<ConvRawBoolExample> for bool`


### PR DESCRIPTION
This PR adds support for deriving boolean for ConvRaw. I mainly wanted to do this because in bitfield structs, if you have single bit values they will be treated like a boolean, even if you specify some other integer type. This is unfortunate. Although I consider this to be a slight workaround, it may be better we force every type wanting to use single bit conversion to have their bitfields specify something like a `u8`, and have that used instead? Either way, let me know how you feel about this, but I could personally make use of allowing conversions from single bit values to enums. (which doesn't seem possible atm?)

For example, something like this
```rust
#[derive(ConvRaw)]
pub enum Boolean {
    False, 
    True,
}

bitfield!(
   struct Example0(u8) {
       // does not compile before this pr. Expects a u8 but gets a boolean. It could be better to maybe address this to make it use
       // u8 if we specify it? 
       field: u8 [Boolean] @ 0, 
   }
);

bitfield!(
   struct Example1(u8) {
       field: bool [Boolean] @ 0, // does not compile before this pr. From<bool> is not implemented.
   }
);
```

Hopefully this illustrates the problem and gives a good solution. 