### PR TITLE
Feature/function get set

### DIFF
--- a/src/example.rs
+++ b/src/example.rs
@@ -184,25 +184,25 @@ bitfield! {
 bitfield! {
     /// A bitfield showcasing how to specify bit ranges.
     #[derive(Clone, Copy, PartialEq, Eq)]
-    pub struct FieldFieldAccessorFunctions(pub u16): Debug, FromRaw, IntoRaw, DerefRaw {
+    pub struct FieldAccessorFunctions(pub u8): Debug, FromRaw, IntoRaw, DerefRaw {
         // A single field without any accessor function.
-        pub no_accessor: u16 @ ..,
+        pub no_accessor: u8 @ ..,
 
         // A single field with a get accessor function.
         // The function takes a `u16` as input, and returns a `u16`.
-        pub get_accessor: u16 [get_fn handle_on_get] @ ..,
+        pub get_accessor: u8 [get_fn handle_on_get] @ ..,
 
         // A single field with a set accessor function.
         // The function takes a `u16` as input, and returns a `u16`.
-        pub set_accessor: u16 [set_fn handle_on_set] @ ..,
+        pub set_accessor: u8 [set_fn handle_on_set] @ ..,
 
         // A single field with a get and set accessor functions.
         // The function takes a `u16` as input, and returns a `u16`.
-        pub get_set_accessors: u16 [get_fn handle_on_get, set_fn handle_on_set] @ ..,
+        pub get_set_accessors: u8 [get_fn handle_on_get, set_fn handle_on_set] @ ..,
 
         // A single field with a get accessor function.
         // The function taken a `NonZeroU8` as input, and returns a `NonZeroU8`.
-        pub get_accessor_with_ty: u16 [NonZeroU8, get_fn handle_on_get] @ ..
+        pub get_accessor_with_ty: u8 [try NonZeroU8, get_fn handle_on_get] @ ..
     }
 }
 

--- a/src/example.rs
+++ b/src/example.rs
@@ -181,6 +181,31 @@ bitfield! {
     }
 }
 
+bitfield! {
+    /// A bitfield showcasing how to specify bit ranges.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub struct FieldFieldAccessorFunctions(pub u16): Debug, FromRaw, IntoRaw, DerefRaw {
+        // A single field without any accessor function.
+        pub no_accessor: u16 @ ..,
+
+        // A single field with a get accessor function.
+        // The function takes a `u16` as input, and returns a `u16`.
+        pub get_accessor: u16 [get_fn handle_on_get] @ ..,
+
+        // A single field with a set accessor function.
+        // The function takes a `u16` as input, and returns a `u16`.
+        pub set_accessor: u16 [set_fn handle_on_set] @ ..,
+
+        // A single field with a get and set accessor functions.
+        // The function takes a `u16` as input, and returns a `u16`.
+        pub get_set_accessors: u16 [get_fn handle_on_get, set_fn handle_on_set] @ ..,
+
+        // A single field with a get accessor function.
+        // The function taken a `NonZeroU8` as input, and returns a `NonZeroU8`.
+        pub get_accessor_with_ty: u16 [NonZeroU8, get_fn handle_on_get] @ ..
+    }
+}
+
 /// An enum showcasing the `ConvRaw` derive.
 #[derive(ConvRaw)]
 pub enum ConvRawExample {

--- a/src/example/support.rs
+++ b/src/example/support.rs
@@ -122,13 +122,13 @@ impl From<UnwrapBitsExample> for u8 {
     }
 }
 
-pub fn handle_on_get<T: Display>(value: T) -> T {
+pub fn handle_on_get<T>(value: T) -> T {
     // Does nothing here, but in a real program this would
     // occur when reading from a field
     value
 }
 
-pub fn handle_on_set<T: Display>(value: T) -> T {
+pub fn handle_on_set<T>(value: T) -> T {
     // Does nothing here, but in a real program this would
     // occur when writing to a field
     value

--- a/src/example/support.rs
+++ b/src/example/support.rs
@@ -121,3 +121,15 @@ impl From<UnwrapBitsExample> for u8 {
         other.0.into()
     }
 }
+
+pub fn handle_on_get<T: Display>(value: T) -> T {
+    // Does nothing here, but in a real program this would
+    // occur when reading from a field
+    value
+}
+
+pub fn handle_on_set<T: Display>(value: T) -> T {
+    // Does nothing here, but in a real program this would
+    // occur when writing to a field
+    value
+}

--- a/usage_examples/bitfield.md
+++ b/usage_examples/bitfield.md
@@ -200,3 +200,35 @@ bitfield! {
     }
 }
 ```
+
+### Field function accessors
+([Generated type docs](https://docs.rs/proc-bitfield/latest/proc_bitfield/example/struct.FieldAccessorFunctions.html))
+
+```rust,ignore
+# use proc_bitfield::bitfield;
+# use proc_bitfield::example::support::*;
+bitfield! {
+    /// A bitfield showcasing how to specify bit ranges.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub struct FieldAccessorFunctions(pub u8): Debug, FromRaw, IntoRaw, DerefRaw {
+        // A single field without any accessor function.
+        pub no_accessor: u8 @ ..,
+
+        // A single field with a get accessor function.
+        // The function takes a `u16` as input, and returns a `u16`.
+        pub get_accessor: u8 [get_fn handle_on_get] @ ..,
+
+        // A single field with a set accessor function.
+        // The function takes a `u16` as input, and returns a `u16`.
+        pub set_accessor: u8 [set_fn handle_on_set] @ ..,
+
+        // A single field with a get and set accessor functions.
+        // The function takes a `u16` as input, and returns a `u16`.
+        pub get_set_accessors: u8 [get_fn handle_on_get, set_fn handle_on_set] @ ..,
+
+        // A single field with a get accessor function.
+        // The function taken a `NonZeroU8` as input, and returns a `NonZeroU8`.
+        pub get_accessor_with_ty: u8 [try NonZeroU8, get_fn handle_on_get] @ ..
+    }
+}
+```


### PR DESCRIPTION
This PR adds the ability to have accessor functions (functions called when a field is accessed (via reading or writing to it). This might be useful if you want  to run additional logic but don't want  to go through types to do so.

The syntax is done through the options field using `[get_fn (expr)]` and `[set_fn (expr)]`.